### PR TITLE
Invocation should not be a module of this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ From the root project you can build and publish the plugin by running the comman
 
 ## Invoking the tooling API
 
-As the next step we can execute the build that uses the custom model registered by the plugin with the tooling API. Navigate to the subdirectory `invocation` and execute the command `../gradlew run`. Executing the command will run a build for the `build.gradle` file in the directory named `sample` on the root level of the repository.
+As the next step we can execute the build that uses the custom model registered by the plugin with the tooling API. 
+Navigate to the subdirectory `invocation` and execute the command `../gradlew run`. 
+Executing the command will run a build for the `build.gradle` file in the directory named `sample` on the root level of the repository.
+If successfully executed, you'll see `JAVA PLUGIN IS FOUND` print out in console.
 
 

--- a/invocation/build.gradle
+++ b/invocation/build.gradle
@@ -11,6 +11,7 @@ repositories {
 }
     
 dependencies {
+    compile gradleApi()
     compile 'org.gradle.sample.plugins.toolingapi:model:1.0'
     compile "org.gradle:gradle-tooling-api:2.1"
     runtime 'org.slf4j:slf4j-simple:1.7.5'

--- a/invocation/src/main/java/org/gradle/sample/toolingapi/ToolingApiRunner.java
+++ b/invocation/src/main/java/org/gradle/sample/toolingapi/ToolingApiRunner.java
@@ -20,6 +20,9 @@ public class ToolingApiRunner {
             customModelBuilder.withArguments("--init-script", "init.gradle"); 
             CustomModel model = customModelBuilder.get();        
             assert model.hasPlugin(JavaPlugin.class);
+
+            System.out.println("JAVA PLUGIN IS FOUND");
+
         } finally {
             if(connection != null) {
                 connection.close();

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include 'model', 'plugin', 'invocation'
+include 'model', 'plugin'


### PR DESCRIPTION
Removing Invocation from list of modules to fix compilation problem - dependency on Model is missing. `./gradlew build publish` was failing...
... although I wonder now how you can unit test `CustomToolingModelBuilder`